### PR TITLE
[DNS-ANDROID] upload-artifact 이름 변경

### DIFF
--- a/.github/workflows/release-dns_lib.yml
+++ b/.github/workflows/release-dns_lib.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Upload dns_lib-debug.aar & dns_lib-release.aar
         uses: actions/upload-artifact@v3
         with:
-          name: dns_lib-*.aar files
+          name: dns_lib aar files
           path: dns_lib/build/outputs/aar/
       - name: Create release note
         uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
# Major changes
### upload-artifact 업로드명 변경
빌드된 aar 파일을 업로드 시 유효하지 않은 이름으로 발생하던 오류를 수정하였습니다.