### PR TITLE
[DNS-ANDROID] release-config-dns_lib 수정

### DIFF
--- a/.github/release-config-dns_lib.yml
+++ b/.github/release-config-dns_lib.yml
@@ -14,8 +14,8 @@ version-resolver:
   default: patch
 template: |
   ## New version of dns_lib has been released!
-  You can download latest-version of dns_lib-debug.aar from [here](https://downgit.github.io/#/home?url=https://github.com/2022DNS/DNS-ANDROID/tree/release/dns_lib/build/outputs/aar/dns_lib-debug.aar)<br>
-  You can download latest-version of dns_lib-release.aar from [here](https://downgit.github.io/#/home?url=https://github.com/2022DNS/DNS-ANDROID/tree/release/dns_lib/build/outputs/aar/dns_lib-release.aar)<br>
+  You can download latest-version of dns_lib-debug.aar from [here](https://github.com/2022DNS/DNS-ANDROID/raw/master/dns_lib/build/outputs/aar/dns_lib-debug.aar)<br>
+  You can download latest-version of dns_lib-release.aar from [here](https://github.com/2022DNS/DNS-ANDROID/raw/master/dns_lib/build/outputs/aar/dns_lib-release.aar)<br>
 
   ## What's new in this version?
   ### 1) Summary

--- a/.github/release-config-dns_lib.yml
+++ b/.github/release-config-dns_lib.yml
@@ -15,7 +15,8 @@ version-resolver:
 template: |
   ## New version of dns_lib has been released!
   You can download latest-version of dns_lib-debug.aar from [here](https://github.com/2022DNS/DNS-ANDROID/raw/master/dns_lib/build/outputs/aar/dns_lib-debug.aar)<br>
-  You can download latest-version of dns_lib-release.aar from [here](https://github.com/2022DNS/DNS-ANDROID/raw/master/dns_lib/build/outputs/aar/dns_lib-release.aar)<br>
+  You can download latest-version of dns_lib-release.aar from [here](https://github.com/2022DNS/DNS-ANDROID/raw/master/dns_lib/build/outputs/aar/dns_lib-release.aar)
+  <br>
 
   ## What's new in this version?
   ### 1) Summary


### PR DESCRIPTION
# Major changes
### Github Action의 Release Note 생성 부분 template 수정
다운로드 경로 밑에 빈줄 추가 및 dns_lib-*.aar의 다운로드 경로가 수정되었습니다.